### PR TITLE
detect conflict inserts

### DIFF
--- a/pkg/app/api/handlers/org/post.go
+++ b/pkg/app/api/handlers/org/post.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/body"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
 )
 
 // Post creates an org.
@@ -58,6 +59,11 @@ func Post(st *app.State) http.HandlerFunc {
 		)
 
 		if createErr != nil {
+			if createErr == models.ErrConflict {
+				logger.Debug("create org", "err", createErr)
+				http.Error(w, "org name in use", http.StatusConflict)
+				return
+			}
 			logger.Error("create org", "err", createErr)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return

--- a/pkg/app/api/handlers/org/testing/post_test.go
+++ b/pkg/app/api/handlers/org/testing/post_test.go
@@ -236,3 +236,33 @@ func (s *OrgSuite) TestPostNoMatchingEvent() {
 	require.NoError(s.T(), postErr)
 	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
+
+func (s *OrgSuite) TestPostConflict() {
+	ev := org.CreateEvent{
+		Name:             safe.TrustedVarChar(security.RandString()),
+		OwnerDisplayName: safe.TrustedVarChar(security.RandString()),
+		OwnerEmail:       safe.TrustedVarChar(security.RandString()),
+		OwnerPassword:    safe.TrustedPassword(security.RandString()),
+		Role:             s.st.DefaultRole,
+	}
+	bs, bsErr := json.Marshal(ev)
+	require.NoError(s.T(), bsErr)
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/org")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(bs))
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, postErr := s.c.Do(req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusCreated, resp.StatusCode)
+
+	// resend with org name already in use
+	req, reqErr = http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(bs))
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, postErr = s.c.Do(req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusConflict, resp.StatusCode)
+}

--- a/pkg/app/api/handlers/user/post.go
+++ b/pkg/app/api/handlers/user/post.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/body"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
 )
 
 func Post(st *app.State) http.HandlerFunc {
@@ -68,6 +69,11 @@ func Post(st *app.State) http.HandlerFunc {
 			st.VersionKey,
 		)
 		if createErr != nil {
+			if createErr == models.ErrConflict {
+				logger.Debug("create err", "err", createErr)
+				http.Error(w, "email already in use in org", http.StatusConflict)
+				return
+			}
 			logger.Error("create err", "err", createErr)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return

--- a/pkg/app/api/handlers/user/testing/post_test.go
+++ b/pkg/app/api/handlers/user/testing/post_test.go
@@ -268,3 +268,37 @@ func (s *UserSuite) TestPostNoMatchingEvent() {
 	require.NoError(s.T(), postErr)
 	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
+
+func (s *UserSuite) TestPostConflict() {
+	conn, connErr := s.st.Master.Acquire(context.Background())
+	require.NoError(s.T(), connErr)
+	defer conn.Release()
+	o, _, _, oErr := app_testing.TestOrgAndUser(conn.Conn(), s.st)
+	require.NoError(s.T(), oErr)
+	ev := user.CreateEvent{
+		DisplayName: safe.TrustedVarChar(security.RandString()),
+		Email:       safe.TrustedVarChar(security.RandString()),
+		Org:         o.ID,
+		Password:    safe.TrustedPassword(security.RandString()),
+	}
+	bs, bsErr := json.Marshal(ev)
+	require.NoError(s.T(), bsErr)
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/user")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(bs))
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, postErr := s.c.Do(req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusCreated, resp.StatusCode)
+
+	// resend with user email already in use in org
+	req, reqErr = http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(bs))
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, postErr = s.c.Do(req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusConflict, resp.StatusCode)
+}


### PR DESCRIPTION
The `orgs` table has a uniqueness constraint on the `name` (all org names unique).

The `users` table has a uniqueness constraint on the `(email,org)` pair (emails unique within an org).

Conflict inserts were not properly detected with the appropriate `409` status code.

 This PR adds this support and tests.