### PR TITLE
refactor user and token code and tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Grokloc
+Copyright (c) 2024 GrokLOC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/grokloc/grokloc-apiserver
 go 1.22.4
 
 require (
-	github.com/go-chi/chi/v5 v5.0.12
+	github.com/go-chi/chi/v5 v5.0.13
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
-github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.0.13 h1:JlH2F2M8qnwl0N1+JFFzlX9TlKJYas3aPXdiuTmJL+w=
+github.com/go-chi/chi/v5 v5.0.13/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/pkg/app/api/handlers/user/testing/put_test.go
+++ b/pkg/app/api/handlers/user/testing/put_test.go
@@ -302,7 +302,7 @@ func (s *UserSuite) TestPutAsRegularUser() {
 	require.NoError(s.T(), putErr)
 	// bad request because the token used has not been refreshed
 	// since the API Secret was changed!
-	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
+	require.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
 
 	// try to update display name again, but first get a new token
 	// first, refresh regularUser to get the new API Secret

--- a/pkg/app/api/middlewares/auth/withtoken/testing/withtoken_test.go
+++ b/pkg/app/api/middlewares/auth/withtoken/testing/withtoken_test.go
@@ -8,159 +8,223 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/user"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/handlers/token"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withtoken"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/jwt"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
+
+	go_jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/state/unit"
+	app_testing "github.com/grokloc/grokloc-apiserver/pkg/app/testing"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
-	app_testing "github.com/grokloc/grokloc-apiserver/pkg/app/testing"
 )
 
 type WithTokenSuite struct {
 	suite.Suite
-	st    *app.State
-	srv   *httptest.Server
-	Org   *org.Org
-	Owner *user.User
-	User  *user.User
-}
-
-type message struct {
-	RequestID string             `json:"request_id"`
-	OrgID     models.ID          `json:"org_id"`
-	UserID    models.ID          `json:"user_id"`
-	Auth      withuser.AuthLevel `json:"auth"`
+	c           http.Client
+	st          *app.State
+	srv         *httptest.Server
+	org         *org.Org
+	owner       *user.User
+	regularUser *user.User
 }
 
 func (s *WithTokenSuite) SetupSuite() {
 	st, stErr := unit.State()
-	require.NoError(s.T(), stErr)
 	s.st = st
+	require.NoError(s.T(), stErr)
 	conn, connErr := s.st.Master.Acquire(context.Background())
 	require.NoError(s.T(), connErr)
 	defer conn.Release()
 
-	org, owner, regularUser, createErr := app_testing.TestOrgAndUser(conn.Conn(), s.st)
+	var createErr error
+	s.org, s.owner, s.regularUser, createErr = app_testing.TestOrgAndUser(conn.Conn(), s.st)
 	require.NoError(s.T(), createErr)
-	s.Org = org
-	s.Owner = owner
-	s.User = regularUser
-	rtr := chi.NewRouter()
-	rtr.Use(request.Middleware(st))
 
-	rtr.Route("/token", func(rtr chi.Router) {
-		rtr.Use(withuser.Middleware(st))
-		rtr.Post("/", token.Post(st))
-	})
-
-	rtr.Route("/message", func(rtr chi.Router) {
-		rtr.Use(withuser.Middleware(st))
-		rtr.Use(withtoken.Middleware(st))
-		rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			var m message
-			m.RequestID = request.GetID(r)
-			o := withuser.GetOrg(r)
-			m.OrgID = o.ID
-			u := withuser.GetUser(r)
-			m.UserID = u.ID
-			a := withuser.GetAuth(r)
-			m.Auth = a
-			bs, err := json.Marshal(m)
-			if err != nil {
-				panic(err.Error())
-			}
-			_, writeErr := w.Write(bs)
-			if writeErr != nil {
-				panic(writeErr.Error())
-			}
-		})
-	})
-
+	rtr := api.NewRouter(st)
 	s.srv = httptest.NewServer(rtr)
+	s.c = http.Client{}
 }
 
-func (s *WithTokenSuite) TestValidToken() {
-	// make token request
-	u, urlErr := url.Parse(s.srv.URL + "/token")
-	require.NoError(s.T(), urlErr)
-	tokenRequest := jwt.EncodeTokenRequest(s.User.ID, s.User.APISecret.String())
-	req0 := http.Request{
-		URL:    u,
+func (s *WithTokenSuite) TestValidAuth() {
+	tokenReqUrl, tokenReqUrlErr := url.Parse(s.srv.URL + "/token")
+	require.NoError(s.T(), tokenReqUrlErr)
+	regularUserTokenRequest := jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	regularUserReq := http.Request{
+		URL:    tokenReqUrl,
 		Method: http.MethodPost,
 		Header: map[string][]string{
-			app.IDHeader:           {s.User.ID.String()},
-			app.TokenRequestHeader: {tokenRequest},
+			app.IDHeader:           {s.regularUser.ID.String()},
+			app.TokenRequestHeader: {regularUserTokenRequest},
 		},
 	}
-	client := http.Client{}
-	resp, postErr := client.Do(&req0)
+	resp, postErr := s.c.Do(&regularUserReq)
 	require.NoError(s.T(), postErr)
 	defer resp.Body.Close()
 	body, readErr := io.ReadAll(resp.Body)
 	require.NoError(s.T(), readErr)
-	var m token.JSONToken
-	umErr := json.Unmarshal(body, &m)
+	var regularUserTok token.JSONToken
+	umErr := json.Unmarshal(body, &regularUserTok)
 	require.NoError(s.T(), umErr)
-	require.NotEmpty(s.T(), m.Token)
-	// m.Token is Authorization header value
-	_, decodeErr := jwt.Decode(m.Token, s.st.SigningKey)
-	require.NoError(s.T(), decodeErr)
+	require.NotEmpty(s.T(), regularUserTok.Token)
 
-	// GET /message with Authorization header set
-	u, urlErr = url.Parse(s.srv.URL + "/message")
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
 	require.NoError(s.T(), urlErr)
-	req1 := http.Request{
-		URL:    u,
-		Method: http.MethodGet,
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+}
+
+func (s *WithTokenSuite) TestMissingToken() {
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	// token is missing
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
+}
+
+func (s *WithTokenSuite) TestWrongID() {
+	tokenReqUrl, tokenReqUrlErr := url.Parse(s.srv.URL + "/token")
+	require.NoError(s.T(), tokenReqUrlErr)
+	regularUserTokenRequest := jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	regularUserReq := http.Request{
+		URL:    tokenReqUrl,
+		Method: http.MethodPost,
 		Header: map[string][]string{
-			app.IDHeader:            {s.User.ID.String()},
-			app.AuthorizationHeader: {jwt.SignedStringToHeaderValue(m.Token)},
+			app.IDHeader:           {s.regularUser.ID.String()},
+			app.TokenRequestHeader: {regularUserTokenRequest},
 		},
 	}
-	var getErr error
-	resp, getErr = client.Do(&req1)
-	require.NoError(s.T(), getErr)
-	require.Equal(s.T(), resp.StatusCode, http.StatusOK)
+	resp, postErr := s.c.Do(&regularUserReq)
+	require.NoError(s.T(), postErr)
 	defer resp.Body.Close()
-	_, readErr = io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	require.NoError(s.T(), readErr)
+	var regularUserTok token.JSONToken
+	umErr := json.Unmarshal(body, &regularUserTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), regularUserTok.Token)
 
-	// try not adding the authorization header at all
-	req2 := http.Request{
-		URL:    u,
-		Method: http.MethodGet,
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String()) // should be regularUser
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+}
+
+func (s *WithTokenSuite) TestWrongAPISecret() {
+	tokenReqUrl, tokenReqUrlErr := url.Parse(s.srv.URL + "/token")
+	require.NoError(s.T(), tokenReqUrlErr)
+	regularUserTokenRequest := jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	regularUserReq := http.Request{
+		URL:    tokenReqUrl,
+		Method: http.MethodPost,
 		Header: map[string][]string{
-			app.IDHeader: {s.User.ID.String()},
+			app.IDHeader:           {s.regularUser.ID.String()},
+			app.TokenRequestHeader: {regularUserTokenRequest},
 		},
 	}
-	resp, getErr = client.Do(&req2)
-	require.NoError(s.T(), getErr)
-	require.Equal(s.T(), resp.StatusCode, http.StatusBadRequest)
+	resp, postErr := s.c.Do(&regularUserReq)
+	require.NoError(s.T(), postErr)
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	var regularUserTok token.JSONToken
+	umErr := json.Unmarshal(body, &regularUserTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), regularUserTok.Token)
 
-	// try mixing the token with a different ID header
-	req3 := http.Request{
-		URL:    u,
-		Method: http.MethodGet,
+	// change regularUser's api secret, invalidating the token
+	conn, connErr := s.st.Master.Acquire(context.Background())
+	require.NoError(s.T(), connErr)
+	defer conn.Release()
+	// generate new, random api secret
+	updateErr := s.regularUser.UpdateAPISecret(context.Background(), conn.Conn(), s.st.VersionKey)
+	require.NoError(s.T(), updateErr)
+
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+}
+
+func (s *WithTokenSuite) TestBadToken() {
+	tokenReqUrl, tokenReqUrlErr := url.Parse(s.srv.URL + "/token")
+	require.NoError(s.T(), tokenReqUrlErr)
+	regularUserTokenRequest := jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	regularUserReq := http.Request{
+		URL:    tokenReqUrl,
+		Method: http.MethodPost,
 		Header: map[string][]string{
-			// s.Owner id
-			app.IDHeader: {s.Owner.ID.String()},
-			// s.User token
-			app.AuthorizationHeader: {jwt.SignedStringToHeaderValue(m.Token)},
+			app.IDHeader:           {s.regularUser.ID.String()},
+			app.TokenRequestHeader: {regularUserTokenRequest},
 		},
 	}
-	resp, getErr = client.Do(&req3)
+	resp, postErr := s.c.Do(&regularUserReq)
+	require.NoError(s.T(), postErr)
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	var regularUserTok token.JSONToken
+	umErr := json.Unmarshal(body, &regularUserTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), regularUserTok.Token)
+
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, "not.a.token") // in place of token
+	resp, getErr := s.c.Do(req)
 	require.NoError(s.T(), getErr)
-	require.Equal(s.T(), resp.StatusCode, http.StatusBadRequest)
+	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
+}
+
+func (s *WithTokenSuite) TestExpiredToken() {
+	now := time.Now().Unix()
+	tokenRequest := jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	tok := go_jwt.NewWithClaims(go_jwt.SigningMethodHS256, go_jwt.MapClaims{
+		"iss": "GrokLOC.com",
+		"sub": tokenRequest,
+		"nbf": now,
+		"iat": now,
+		"exp": now - jwt.Expiration,
+	})
+	regularUserToken, tokenErr := tok.SignedString(s.st.SigningKey)
+	require.NoError(s.T(), tokenErr)
+
+	u, urlErr := url.Parse(s.srv.URL + "/api/" + s.st.APIVersion + "/ok")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(regularUserToken))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
 }
 
 func (s *WithTokenSuite) TearDownSuite() {

--- a/pkg/app/api/middlewares/auth/withtoken/withtoken.go
+++ b/pkg/app/api/middlewares/auth/withtoken/withtoken.go
@@ -3,7 +3,6 @@ package withtoken
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
@@ -12,7 +11,6 @@ import (
 )
 
 // Middleware tests the Authorization header.
-// Assumes request and withuser middlewares.
 func Middleware(st *app.State) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
@@ -29,21 +27,8 @@ func Middleware(st *app.State) func(http.Handler) http.Handler {
 			// decode token
 			token, tokenErr := jwt.Decode(signedToken, st.SigningKey)
 			if tokenErr != nil {
-				logger.Error("token decode", "err", tokenErr)
-				http.Error(w, "malformed token", http.StatusBadRequest)
-				return
-			}
-
-			// test expiration
-			exp, expErr := token.Claims.GetExpirationTime()
-			if expErr != nil {
-				logger.Debug("token validate", "invalid expiration", expErr)
-				http.Error(w, "malformed token", http.StatusBadRequest)
-				return
-			}
-			if time.Now().After(exp.Time) {
-				logger.Debug("token expired")
-				http.Error(w, "token expired", http.StatusBadRequest)
+				logger.Debug("token decode", "err", tokenErr)
+				http.Error(w, "invalid token", http.StatusBadRequest)
 				return
 			}
 
@@ -51,15 +36,18 @@ func Middleware(st *app.State) func(http.Handler) http.Handler {
 			subject, subjectErr := token.Claims.GetSubject()
 			if subjectErr != nil {
 				logger.Debug("token claims sub missing")
-				http.Error(w, "malformed token", http.StatusBadRequest)
+				http.Error(w, "token subject is missing", http.StatusBadRequest)
 				return
 			}
-			u := withuser.GetUser(r) // assume withuser middleware
-			// if u.APISecret has been changed since the token was issued,
-			// this will fail (caller must get a new token)
+			u := withuser.GetUser(r)
+			// provides two kinds of protection:
+			// 1. requires caller token to match caller user id
+			// 2. protects against api secret changing:
+			//    if u.APISecret has been changed since the token was issued,
+			//    this will fail (caller must get a new token)
 			if jwt.EncodeTokenRequest(u.ID, u.APISecret.String()) != subject {
-				logger.Debug("claims subject does not match token request", "sub", subject)
-				http.Error(w, "malformed token", http.StatusBadRequest)
+				logger.Debug("claims subject does not match token request id and/or api secret", "sub", subject)
+				http.Error(w, "malformed token", http.StatusUnauthorized)
 				return
 			}
 

--- a/pkg/app/api/middlewares/auth/withuser/testing/withuser_test.go
+++ b/pkg/app/api/middlewares/auth/withuser/testing/withuser_test.go
@@ -2,8 +2,6 @@ package testing
 
 import (
 	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +9,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/user"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
@@ -22,18 +22,11 @@ import (
 
 type WithUserSuite struct {
 	suite.Suite
-	st      *app.State
-	srv     *httptest.Server
-	OrgID   models.ID
-	OwnerID models.ID
-	UserID  models.ID
-}
-
-type message struct {
-	RequestID string             `json:"request_id"`
-	OrgID     models.ID          `json:"org_id"`
-	UserID    models.ID          `json:"user_id"`
-	Auth      withuser.AuthLevel `json:"auth"`
+	st          *app.State
+	srv         *httptest.Server
+	org         *org.Org
+	owner       *user.User
+	regularUser *user.User
 }
 
 func (s *WithUserSuite) SetupSuite() {
@@ -44,59 +37,32 @@ func (s *WithUserSuite) SetupSuite() {
 	require.NoError(s.T(), connErr)
 	defer conn.Release()
 
-	org, owner, regularUser, createErr := app_testing.TestOrgAndUser(conn.Conn(), s.st)
+	var createErr error
+	s.org, s.owner, s.regularUser, createErr = app_testing.TestOrgAndUser(conn.Conn(), s.st)
 	require.NoError(s.T(), createErr)
-	s.OrgID = org.ID
-	s.OwnerID = owner.ID
-	s.UserID = regularUser.ID
-	rtr := chi.NewRouter()
 
+	rtr := chi.NewRouter()
 	rtr.Use(request.Middleware(st))
 	rtr.Use(withuser.Middleware(st))
-	rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		var m message
-		m.RequestID = request.GetID(r)
-		o := withuser.GetOrg(r)
-		m.OrgID = o.ID
-		u := withuser.GetUser(r)
-		m.UserID = u.ID
-		a := withuser.GetAuth(r)
-		m.Auth = a
-		bs, err := json.Marshal(m)
-		if err != nil {
-			panic(err.Error())
-		}
-		_, writeErr := w.Write(bs)
-		if writeErr != nil {
-			panic(writeErr.Error())
-		}
-	})
+	rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {})
 
 	s.srv = httptest.NewServer(rtr)
 }
 
-func (s *WithUserSuite) TestWithUser() {
+func (s *WithUserSuite) TestWithRegularUser() {
 	u, urlErr := url.Parse(s.srv.URL + "/")
 	require.NoError(s.T(), urlErr)
 	req := http.Request{
 		URL:    u,
 		Method: http.MethodGet,
 		Header: map[string][]string{
-			app.IDHeader: {s.UserID.String()},
+			app.IDHeader: {s.regularUser.ID.String()},
 		},
 	}
 	client := http.Client{}
 	resp, getErr := client.Do(&req)
 	require.NoError(s.T(), getErr)
-	defer resp.Body.Close()
-	body, readErr := io.ReadAll(resp.Body)
-	require.NoError(s.T(), readErr)
-	var m message
-	umErr := json.Unmarshal(body, &m)
-	require.NoError(s.T(), umErr)
-	require.Equal(s.T(), s.OrgID, m.OrgID)
-	require.Equal(s.T(), s.UserID, m.UserID)
-	require.Equal(s.T(), withuser.AuthUser, m.Auth)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
 }
 
 func (s *WithUserSuite) TestWithUserOrgOwner() {
@@ -106,21 +72,13 @@ func (s *WithUserSuite) TestWithUserOrgOwner() {
 		URL:    u,
 		Method: http.MethodGet,
 		Header: map[string][]string{
-			app.IDHeader: {s.OwnerID.String()},
+			app.IDHeader: {s.owner.ID.String()},
 		},
 	}
 	client := http.Client{}
 	resp, getErr := client.Do(&req)
 	require.NoError(s.T(), getErr)
-	defer resp.Body.Close()
-	body, readErr := io.ReadAll(resp.Body)
-	require.NoError(s.T(), readErr)
-	var m message
-	umErr := json.Unmarshal(body, &m)
-	require.NoError(s.T(), umErr)
-	require.Equal(s.T(), s.OrgID, m.OrgID)
-	require.Equal(s.T(), s.OwnerID, m.UserID)
-	require.Equal(s.T(), withuser.AuthOrg, m.Auth)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
 }
 
 func (s *WithUserSuite) TestWithUserRootUser() {
@@ -136,15 +94,7 @@ func (s *WithUserSuite) TestWithUserRootUser() {
 	client := http.Client{}
 	resp, getErr := client.Do(&req)
 	require.NoError(s.T(), getErr)
-	defer resp.Body.Close()
-	body, readErr := io.ReadAll(resp.Body)
-	require.NoError(s.T(), readErr)
-	var m message
-	umErr := json.Unmarshal(body, &m)
-	require.NoError(s.T(), umErr)
-	require.Equal(s.T(), s.st.Org.ID, m.OrgID)
-	require.Equal(s.T(), s.st.Root.ID, m.UserID)
-	require.Equal(s.T(), withuser.AuthRoot, m.Auth)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
 }
 
 func (s *WithUserSuite) TestWithUserMissingUser() {

--- a/pkg/app/api/middlewares/auth/withuser/withuser.go
+++ b/pkg/app/api/middlewares/auth/withuser/withuser.go
@@ -51,8 +51,6 @@ func newAuthLevel(authLevel int) (AuthLevel, error) {
 }
 
 // Middleware checks user and org for the incoming request.
-// These are set in the request logger.
-// Assumes request middleware.
 func Middleware(st *app.State) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
provide a better distinction between auth scenarios related to user state (resulting in http 401) and bad tokens (resulting in http 400)

also rewrite the tests to be aligned with design choices elsewhere in the code