### PR TITLE
add auth as a middleware

### DIFF
--- a/pkg/app/admin/org/model.go
+++ b/pkg/app/admin/org/model.go
@@ -23,4 +23,9 @@ func (o *Org) GetOrg() models.ID {
 	return o.GetID()
 }
 
+// GetOrg implements models.WithUser.
+func (o *Org) GetUser() models.ID {
+	return o.Owner
+}
+
 const SchemaVersion = 0

--- a/pkg/app/admin/user/model.go
+++ b/pkg/app/admin/user/model.go
@@ -35,4 +35,9 @@ func (u *User) GetOrg() models.ID {
 	return u.Org
 }
 
+// GetUser implements models.WithUser.
+func (u *User) GetUser() models.ID {
+	return u.GetID()
+}
+
 const SchemaVersion = 0

--- a/pkg/app/api/handlers/org/delete.go
+++ b/pkg/app/api/handlers/org/delete.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
@@ -15,13 +14,6 @@ import (
 func Delete(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		if withuser.GetAuth(r) != withuser.AuthRoot {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		acquireCtx, acquireCancel := context.WithTimeout(context.Background(), st.ConnTimeout)
 		defer acquireCancel()

--- a/pkg/app/api/handlers/org/get.go
+++ b/pkg/app/api/handlers/org/get.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
@@ -16,17 +15,6 @@ import (
 func Get(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		auth := withuser.GetAuth(r)
-		authOK := auth == withuser.AuthRoot ||
-			auth == withuser.AuthOrg &&
-				withuser.GetOrg(r).GetID() == withmodel.GetModelWithOrg(r).GetOrg()
-		if !authOK {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		modelObject := withmodel.GetModelAny(r)
 		o, ok := modelObject.(*org.Org)

--- a/pkg/app/api/handlers/org/post.go
+++ b/pkg/app/api/handlers/org/post.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/body"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
@@ -17,13 +16,6 @@ import (
 func Post(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		if withuser.GetAuth(r) != withuser.AuthRoot {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		ev, evErr := org.NewCreateEvent(&st.Argon2Config)
 		if evErr != nil {

--- a/pkg/app/api/handlers/org/put.go
+++ b/pkg/app/api/handlers/org/put.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/body"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
@@ -32,13 +31,6 @@ func decodeToUpdateOwnerEvent(body []byte, v *org.UpdateOwnerEvent) bool {
 func Put(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		if withuser.GetAuth(r) != withuser.AuthRoot {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		acquireCtx, acquireCancel := context.WithTimeout(context.Background(), st.ConnTimeout)
 		defer acquireCancel()

--- a/pkg/app/api/handlers/org/users.go
+++ b/pkg/app/api/handlers/org/users.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
@@ -18,17 +17,6 @@ import (
 func Users(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		auth := withuser.GetAuth(r)
-		authOK := auth == withuser.AuthRoot ||
-			auth == withuser.AuthOrg &&
-				withuser.GetOrg(r).GetID() == withmodel.GetModelWithOrg(r).GetOrg()
-		if !authOK {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		modelObject := withmodel.GetModelAny(r)
 		o, ok := modelObject.(*org.Org)

--- a/pkg/app/api/handlers/user/delete.go
+++ b/pkg/app/api/handlers/user/delete.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/user"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
@@ -17,17 +16,6 @@ import (
 func Delete(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		auth := withuser.GetAuth(r)
-		authOK := auth == withuser.AuthRoot ||
-			// org owner, user to be deleted is in org
-			auth == withuser.AuthOrg && withuser.GetOrg(r).GetID() == withmodel.GetModelWithOrg(r).GetOrg()
-		if !authOK {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		acquireCtx, acquireCancel := context.WithTimeout(context.Background(), st.ConnTimeout)
 		defer acquireCancel()

--- a/pkg/app/api/handlers/user/get.go
+++ b/pkg/app/api/handlers/user/get.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grokloc/grokloc-apiserver/pkg/app"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/user"
-	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/render"
@@ -15,19 +14,6 @@ import (
 func Get(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
-
-		auth := withuser.GetAuth(r)
-		authOK := auth == withuser.AuthRoot ||
-			// org owner, user to be viewed is in org
-			auth == withuser.AuthOrg && withuser.GetOrg(r).GetID() == withmodel.GetModelWithOrg(r).GetOrg() ||
-			// user viewing themselves
-			auth == withuser.AuthUser && withuser.GetUser(r).GetID() == withmodel.GetModelWithID(r).GetID()
-		if !authOK {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		modelObject := withmodel.GetModelAny(r)
 		u, ok := modelObject.(*user.User)

--- a/pkg/app/api/handlers/user/put.go
+++ b/pkg/app/api/handlers/user/put.go
@@ -45,19 +45,8 @@ func Put(st *app.State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := request.GetLogger(r)
 
-		// specific exceptions to these auth rules will follow for each update case below
+		// some updates have special limitations on auth
 		auth := withuser.GetAuth(r)
-		authOK := auth == withuser.AuthRoot ||
-			// org owner, user to be updated is in org
-			auth == withuser.AuthOrg && withuser.GetOrg(r).GetID() == withmodel.GetModelWithOrg(r).GetOrg() ||
-			// user updating themselves
-			auth == withuser.AuthUser && withuser.GetUser(r).GetID() == withmodel.GetModelWithID(r).GetID()
-		if !authOK {
-			logger.Debug("expected auth level not satisfied",
-				"err", app.ErrorInadequateAuthorization)
-			http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
-			return
-		}
 
 		modelObject := withmodel.GetModelAny(r)
 		u, ok := modelObject.(*user.User)

--- a/pkg/app/api/middlewares/auth/withauth/testing/withauth_test.go
+++ b/pkg/app/api/middlewares/auth/withauth/testing/withauth_test.go
@@ -1,0 +1,357 @@
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/grokloc/grokloc-apiserver/pkg/app"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/org"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/admin/user"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/handlers/token"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withauth"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/jwt"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/models"
+	"github.com/grokloc/grokloc-apiserver/pkg/safe"
+	"github.com/grokloc/grokloc-apiserver/pkg/security"
+
+	"github.com/grokloc/grokloc-apiserver/pkg/app/state/unit"
+	app_testing "github.com/grokloc/grokloc-apiserver/pkg/app/testing"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type WithAuthSuite struct {
+	suite.Suite
+	c                                          http.Client
+	o                                          *org.Org
+	owner, regularUser, peerUser               *user.User
+	srv                                        *httptest.Server
+	st                                         *app.State
+	tok, ownerTok, regularUserTok, peerUserTok token.JSONToken
+}
+
+func (s *WithAuthSuite) SetupSuite() {
+	st, stErr := unit.State()
+	require.NoError(s.T(), stErr)
+	s.st = st
+	s.c = http.Client{}
+
+	rtr := chi.NewRouter()
+	rtr.Use(request.Middleware(st))
+	rtr.Use(withuser.Middleware(st))
+	rtr.Route("/token", func(rtr chi.Router) {
+		rtr.Post("/", token.Post(st))
+	})
+	rtr.Route("/root", func(rtr chi.Router) {
+		rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot))
+		rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {})
+	})
+	rtr.Route("/org", func(rtr chi.Router) {
+		rtr.Route("/{id}", func(rtr chi.Router) {
+			rtr.Use(withmodel.Middleware(st, models.KindOrg))
+			rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg))
+			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {})
+		})
+	})
+	rtr.Route("/user", func(rtr chi.Router) {
+		rtr.Route("/{id}", func(rtr chi.Router) {
+			rtr.Use(withmodel.Middleware(st, models.KindUser))
+			rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg, withuser.AuthUser))
+			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {})
+		})
+	})
+	rtr.Route("/peer", func(rtr chi.Router) {
+		rtr.Route("/{id}", func(rtr chi.Router) {
+			rtr.Use(withmodel.Middleware(st, models.KindUser))
+			rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg, withuser.AuthUser, withuser.AuthPeer))
+			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {})
+		})
+	})
+
+	s.srv = httptest.NewServer(rtr)
+
+	conn, connErr := s.st.Master.Acquire(context.Background())
+	require.NoError(s.T(), connErr)
+	defer conn.Release()
+	var createErr error
+	s.o, s.owner, s.regularUser, createErr = app_testing.TestOrgAndUser(conn.Conn(), s.st)
+	require.NoError(s.T(), createErr)
+
+	displayName := safe.TrustedVarChar(security.RandString())
+	email := safe.TrustedVarChar(security.RandString())
+	password, passwordErr := security.DerivePassword(security.RandString(), s.st.Argon2Config)
+	require.NoError(s.T(), passwordErr)
+	s.peerUser, createErr = user.Create(context.Background(), conn.Conn(), displayName, email, s.o.ID, *password, st.VersionKey)
+	require.NoError(s.T(), createErr)
+	require.NoError(s.T(), s.peerUser.UpdateStatus(context.Background(), conn.Conn(), st.VersionKey, models.StatusActive))
+
+	u, urlErr := url.Parse(s.srv.URL + "/token")
+	require.NoError(s.T(), urlErr)
+	tokenRequest := jwt.EncodeTokenRequest(s.st.Root.ID, s.st.Root.APISecret.String())
+	req := http.Request{
+		URL:    u,
+		Method: http.MethodPost,
+		Header: map[string][]string{
+			app.IDHeader:           {s.st.Root.ID.String()},
+			app.TokenRequestHeader: {tokenRequest},
+		},
+	}
+	resp, postErr := s.c.Do(&req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	umErr := json.Unmarshal(body, &s.tok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), s.tok.Token)
+
+	tokenRequest = jwt.EncodeTokenRequest(s.owner.ID, s.owner.APISecret.String())
+	req = http.Request{
+		URL:    u,
+		Method: http.MethodPost,
+		Header: map[string][]string{
+			app.IDHeader:           {s.owner.ID.String()},
+			app.TokenRequestHeader: {tokenRequest},
+		},
+	}
+	resp, postErr = s.c.Do(&req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	body, readErr = io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	umErr = json.Unmarshal(body, &s.ownerTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), s.ownerTok.Token)
+
+	tokenRequest = jwt.EncodeTokenRequest(s.regularUser.ID, s.regularUser.APISecret.String())
+	req = http.Request{
+		URL:    u,
+		Method: http.MethodPost,
+		Header: map[string][]string{
+			app.IDHeader:           {s.regularUser.ID.String()},
+			app.TokenRequestHeader: {tokenRequest},
+		},
+	}
+	resp, postErr = s.c.Do(&req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	body, readErr = io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	umErr = json.Unmarshal(body, &s.regularUserTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), s.regularUserTok.Token)
+
+	tokenRequest = jwt.EncodeTokenRequest(s.peerUser.ID, s.peerUser.APISecret.String())
+	req = http.Request{
+		URL:    u,
+		Method: http.MethodPost,
+		Header: map[string][]string{
+			app.IDHeader:           {s.peerUser.ID.String()},
+			app.TokenRequestHeader: {tokenRequest},
+		},
+	}
+	resp, postErr = s.c.Do(&req)
+	require.NoError(s.T(), postErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+	body, readErr = io.ReadAll(resp.Body)
+	require.NoError(s.T(), readErr)
+	umErr = json.Unmarshal(body, &s.peerUserTok)
+	require.NoError(s.T(), umErr)
+	require.NotEmpty(s.T(), s.peerUserTok.Token)
+}
+
+func (s *WithAuthSuite) TestRootAuthAsRoot() {
+	u, urlErr := url.Parse(s.srv.URL + "/root")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestRootAuthAsOrgOwner() {
+	u, urlErr := url.Parse(s.srv.URL + "/root")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.ownerTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestRootAuthAsRegularUser() {
+	u, urlErr := url.Parse(s.srv.URL + "/root")
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestOrgAuthAsRoot() {
+	u, urlErr := url.Parse(s.srv.URL + "/org/" + s.o.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestOrgAuthAsOrgOwner() {
+	u, urlErr := url.Parse(s.srv.URL + "/org/" + s.o.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.ownerTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+
+	// try accessing a different org
+	u, urlErr = url.Parse(s.srv.URL + "/org/" + s.st.Org.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr = http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.ownerTok.Token))
+	resp, getErr = s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestOrgAuthAsRegularUser() {
+	u, urlErr := url.Parse(s.srv.URL + "/org/" + s.o.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestUserAuthAsRoot() {
+	u, urlErr := url.Parse(s.srv.URL + "/user/" + s.regularUser.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.st.Root.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.tok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestUserAuthAsOrgOwner() {
+	u, urlErr := url.Parse(s.srv.URL + "/user/" + s.regularUser.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.ownerTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+
+	// try a user in a different org
+	u, urlErr = url.Parse(s.srv.URL + "/user/" + s.st.Root.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr = http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.owner.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.ownerTok.Token))
+	resp, getErr = s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestUserAuthAsRegularUser() {
+	u, urlErr := url.Parse(s.srv.URL + "/user/" + s.regularUser.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.regularUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+
+	// try with a different user in user's org
+	u, urlErr = url.Parse(s.srv.URL + "/user/" + s.peerUser.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr = http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.regularUserTok.Token))
+	resp, getErr = s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+
+	// try with a user in other org
+	u, urlErr = url.Parse(s.srv.URL + "/user/" + s.st.Root.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr = http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.regularUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.regularUserTok.Token))
+	resp, getErr = s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TestUserAuthAsPeerUser() {
+	u, urlErr := url.Parse(s.srv.URL + "/peer/" + s.regularUser.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr := http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.peerUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.peerUserTok.Token))
+	resp, getErr := s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusOK, resp.StatusCode)
+
+	// try with a user in other org
+	u, urlErr = url.Parse(s.srv.URL + "/peer/" + s.st.Root.ID.String())
+	require.NoError(s.T(), urlErr)
+	req, reqErr = http.NewRequest(http.MethodGet, u.String(), nil)
+	require.NoError(s.T(), reqErr)
+	req.Header.Add(app.IDHeader, s.peerUser.ID.String())
+	req.Header.Add(app.AuthorizationHeader, jwt.SignedStringToHeaderValue(s.peerUserTok.Token))
+	resp, getErr = s.c.Do(req)
+	require.NoError(s.T(), getErr)
+	require.Equal(s.T(), http.StatusForbidden, resp.StatusCode)
+}
+
+func (s *WithAuthSuite) TearDownSuite() {
+	s.srv.Close()
+}
+
+func TestWithAuthSuite(t *testing.T) {
+	suite.Run(t, new(WithAuthSuite))
+}

--- a/pkg/app/api/middlewares/auth/withauth/withauth.go
+++ b/pkg/app/api/middlewares/auth/withauth/withauth.go
@@ -1,0 +1,52 @@
+package withauth
+
+import (
+	"net/http"
+
+	"github.com/grokloc/grokloc-apiserver/pkg/app"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/request"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/withmodel"
+)
+
+// RequireOneOf provides simple auth filtering based on auth levels.
+func RequireOneOf(st *app.State, levels ...withuser.AuthLevel) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			logger := request.GetLogger(r)
+
+			auth := withuser.GetAuth(r)
+
+			satisfied := false
+			for _, level := range levels {
+				if (level == withuser.AuthRoot && auth == withuser.AuthRoot) ||
+					// AuthOrg level, calling user has auth level AuthOrg and
+					// calling user's org is the same as the org for the model
+					(level == withuser.AuthOrg && auth == withuser.AuthOrg &&
+						withmodel.GetModelWithOrg(r).GetOrg() == withuser.GetOrg(r).ID) ||
+					// AuthUser level, calling user has auth level AuthUser and
+					// calling user's ID is the same as the user for the model
+					(level == withuser.AuthUser && auth == withuser.AuthUser &&
+						withmodel.GetModelWithUser(r).GetUser() == withuser.GetUser(r).ID) ||
+					// AuthPeer level, calling user has auth level AuthUser and
+					// calling user's org is the same as the org for the model
+					// (calling user is a peer in the same org)
+					(level == withuser.AuthPeer && auth == withuser.AuthUser &&
+						withmodel.GetModelWithOrg(r).GetOrg() == withuser.GetOrg(r).ID) {
+					satisfied = true
+					break
+				}
+			}
+
+			if !satisfied {
+				logger.Debug("expected auth level not satisfied",
+					"err", app.ErrorInadequateAuthorization)
+				http.Error(w, app.ErrorInadequateAuthorization.Error(), http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/pkg/app/api/middlewares/auth/withuser/withuser.go
+++ b/pkg/app/api/middlewares/auth/withuser/withuser.go
@@ -35,6 +35,7 @@ const (
 	AuthUser = AuthLevel(1)
 	AuthOrg  = AuthLevel(2)
 	AuthRoot = AuthLevel(3)
+	AuthPeer = AuthLevel(4)
 )
 
 func newAuthLevel(authLevel int) (AuthLevel, error) {
@@ -45,6 +46,8 @@ func newAuthLevel(authLevel int) (AuthLevel, error) {
 		return AuthOrg, nil
 	case 3:
 		return AuthRoot, nil
+	case 4:
+		return AuthPeer, nil
 	default:
 		return AuthNone, ErrorAuthLevelInvalid
 	}

--- a/pkg/app/api/middlewares/withmodel/testing/withmodel_test.go
+++ b/pkg/app/api/middlewares/withmodel/testing/withmodel_test.go
@@ -32,7 +32,6 @@ func (s *WithModelSuite) SetupSuite() {
 		rtr.Route("/{id}", func(rtr chi.Router) {
 			rtr.Use(withmodel.Middleware(st, models.KindOrg))
 			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				_ = withmodel.GetModelWithID(r)
 				_ = withmodel.GetModelWithOrg(r)
 			})
 		})
@@ -41,8 +40,7 @@ func (s *WithModelSuite) SetupSuite() {
 		rtr.Route("/{id}", func(rtr chi.Router) {
 			rtr.Use(withmodel.Middleware(st, models.KindUser))
 			rtr.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				_ = withmodel.GetModelWithID(r)
-				_ = withmodel.GetModelWithOrg(r)
+				_ = withmodel.GetModelWithUser(r)
 			})
 		})
 	})

--- a/pkg/app/api/middlewares/withmodel/withmodel.go
+++ b/pkg/app/api/middlewares/withmodel/withmodel.go
@@ -121,6 +121,20 @@ func GetModelWithOrg(r *http.Request) models.WithOrg {
 	return modelWithOrg
 }
 
+// GetWithUser returns the model object as a models.WithUser instance.
+// Panic indicates coding error.
+func GetModelWithUser(r *http.Request) models.WithUser {
+	v := r.Context().Value(ModelKey)
+	if v == nil {
+		panic("retrieve modelObject from context")
+	}
+	modelWithUser, a := v.(models.WithUser)
+	if !a {
+		panic("assert modelObject -> models.WithUser")
+	}
+	return modelWithUser
+}
+
 // GetWithID returns the model object as a models.WithID instance.
 // Panic indicates coding error.
 func GetModelWithID(r *http.Request) models.WithID {

--- a/pkg/app/api/router.go
+++ b/pkg/app/api/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/handlers/org"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/handlers/token"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/handlers/user"
+	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withauth"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withtoken"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/auth/withuser"
 	"github.com/grokloc/grokloc-apiserver/pkg/app/api/middlewares/body"
@@ -46,29 +47,46 @@ func NewRouter(st *app.State) *chi.Mux {
 		// org related
 		rtr.Route("/org", func(rtr chi.Router) {
 			rtr.With(body.Middleware()).
+				With(withauth.RequireOneOf(st, withuser.AuthRoot)).
 				Post("/", org.Post(st))
 
 			rtr.Route("/{id}", func(rtr chi.Router) {
 				rtr.Use(withmodel.Middleware(st, models.KindOrg))
-				rtr.Get("/", org.Get(st))
-				rtr.Get("/users", org.Users(st))
-				rtr.Delete("/", org.Delete(st))
-				rtr.With(body.Middleware()).
-					Put("/", org.Put(st))
+				rtr.Group(func(rtr chi.Router) {
+					rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg))
+
+					rtr.Get("/", org.Get(st))
+
+					rtr.Get("/users", org.Users(st))
+				})
+				rtr.Group(func(rtr chi.Router) {
+					rtr.Use(withauth.RequireOneOf(st, withuser.AuthRoot))
+
+					rtr.Delete("/", org.Delete(st))
+
+					rtr.With(body.Middleware()).
+						Put("/", org.Put(st))
+				})
 			})
 		})
 
 		// user related
 		rtr.Route("/user", func(rtr chi.Router) {
 			rtr.With(body.Middleware()).
-				Post("/", user.Post(st))
+				Post("/", user.Post(st)) // auth enforced in handler
 
 			rtr.Route("/{id}", func(rtr chi.Router) {
 				rtr.Use(withmodel.Middleware(st, models.KindUser))
-				rtr.Get("/", user.Get(st))
-				rtr.Delete("/", user.Delete(st))
+
+				rtr.With(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg, withuser.AuthUser)).
+					Get("/", user.Get(st))
+
+				rtr.With(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg)).
+					Delete("/", user.Delete(st))
+
 				rtr.With(body.Middleware()).
-					Put("/", user.Put(st))
+					With(withauth.RequireOneOf(st, withuser.AuthRoot, withuser.AuthOrg, withuser.AuthUser)).
+					Put("/", user.Put(st)) // some refined auth rules in handler
 			})
 		})
 	})

--- a/pkg/app/models/models.go
+++ b/pkg/app/models/models.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// WithID indicates a model has a retrievable ID.
+// WithID indicates a model has a retrievable model ID.
 type WithID interface {
 	GetID() ID
 }
@@ -20,6 +20,11 @@ type WithID interface {
 // WithOrg indicates a model has a retrievable Org ID.
 type WithOrg interface {
 	GetOrg() ID
+}
+
+// WithUser indicates a model has a retrievable User ID.
+type WithUser interface {
+	GetUser() ID
 }
 
 // Kind is a symbol for a model kind.


### PR DESCRIPTION
 A second take on this.

Introduce a middleware for enforcing most (not all) auth scenarios based on auth level assigned to caller + id/org of model that is the subject of a particular handler.